### PR TITLE
fix: Replace private Prometheus registry access and rewrite middleware as pure ASGI

### DIFF
--- a/fastapi_telemetry/helpers.py
+++ b/fastapi_telemetry/helpers.py
@@ -3,11 +3,28 @@ Prometheus metric registration helpers.
 
 These helpers prevent ``ValueError: Duplicated timeseries`` errors that occur
 when uvicorn restarts the ASGI application with ``--reload``.  Each function
-first tries to register a new metric; on failure it retrieves the already-
-registered metric from the Prometheus registry.
+looks up the metric in a module-level registry dict first; if absent it
+creates and registers a new metric.  This avoids accessing private
+``prometheus_client`` internals that may change across library versions.
 """
 
 from prometheus_client import REGISTRY, Counter, Gauge, Histogram
+
+_registry: dict[str, Counter | Gauge | Histogram] = {}
+
+
+def _clear_registry(*names: str) -> None:
+    """Unregister named metrics from both the module cache and Prometheus REGISTRY.
+
+    Intended for test teardown only.
+    """
+    for name in names:
+        collector = _registry.pop(name, None)
+        if collector is not None:
+            try:
+                REGISTRY.unregister(collector)
+            except ValueError:
+                pass
 
 
 def get_or_create_counter(
@@ -35,10 +52,9 @@ def get_or_create_counter(
         )
         requests_total.labels(method="GET", status="200").inc()
     """
-    try:
-        return Counter(name, doc, labels or [])
-    except ValueError:
-        return REGISTRY._names_to_collectors[name]  # type: ignore[return-value]
+    if name not in _registry:
+        _registry[name] = Counter(name, doc, labels or [])
+    return _registry[name]  # type: ignore[return-value]
 
 
 def get_or_create_gauge(
@@ -57,10 +73,9 @@ def get_or_create_gauge(
     Returns:
         Gauge instance (new or pre-existing).
     """
-    try:
-        return Gauge(name, doc, labels or [])
-    except ValueError:
-        return REGISTRY._names_to_collectors[name]  # type: ignore[return-value]
+    if name not in _registry:
+        _registry[name] = Gauge(name, doc, labels or [])
+    return _registry[name]  # type: ignore[return-value]
 
 
 def get_or_create_histogram(
@@ -81,9 +96,9 @@ def get_or_create_histogram(
     Returns:
         Histogram instance (new or pre-existing).
     """
-    try:
+    if name not in _registry:
         if buckets:
-            return Histogram(name, doc, labels or [], buckets=buckets)
-        return Histogram(name, doc, labels or [])
-    except ValueError:
-        return REGISTRY._names_to_collectors[name]  # type: ignore[return-value]
+            _registry[name] = Histogram(name, doc, labels or [], buckets=buckets)
+        else:
+            _registry[name] = Histogram(name, doc, labels or [])
+    return _registry[name]  # type: ignore[return-value]

--- a/fastapi_telemetry/middleware.py
+++ b/fastapi_telemetry/middleware.py
@@ -4,18 +4,18 @@ Prometheus HTTP metrics middleware.
 Tracks request counts, durations, and in-progress requests via injectable
 callbacks so the middleware has no dependency on any app-specific metrics
 facade.
+
+Implemented as a pure ASGI middleware (not ``BaseHTTPMiddleware``) to avoid
+buffering streaming responses in memory.
 """
 
 import time
 from collections.abc import Callable
 
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import Request
-from starlette.responses import Response
-from starlette.types import ASGIApp
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 
-class PrometheusMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
+class PrometheusMiddleware:
     """
     ASGI middleware that records Prometheus HTTP metrics.
 
@@ -52,45 +52,43 @@ class PrometheusMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
         request_end_callback: Callable[[str, str, int, float], None] | None = None,
         error_callback: Callable[[str, str], None] | None = None,
     ) -> None:
-        """Initialise the middleware with optional metric callbacks."""
-        super().__init__(app)
+        self.app = app
         self._on_start = request_start_callback
         self._on_end = request_end_callback
         self._on_error = error_callback
 
-    async def dispatch(self, request: Request, call_next: ASGIApp) -> Response:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         Process the request and invoke metric callbacks.
 
-        Args:
-            request: Incoming HTTP request.
-            call_next: Next middleware or endpoint handler.
-
-        Returns:
-            HTTP response from the endpoint.
+        Non-HTTP scopes (WebSocket, lifespan) are passed through unchanged.
         """
-        method = request.method
-        path = request.url.path
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method = scope["method"]
+        path = scope["path"]
 
         if self._on_start:
             self._on_start(method, path)
 
-        start = time.time()
+        status_code = 500
+
+        async def send_wrapper(message: dict) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+            await send(message)
+
+        start = time.monotonic()
         try:
-            response = await call_next(request)
-            duration = time.time() - start
-
+            await self.app(scope, receive, send_wrapper)
             if self._on_end:
-                self._on_end(method, path, response.status_code, duration)
-
-            return response
-
+                self._on_end(method, path, status_code, time.monotonic() - start)
         except Exception as exc:
-            duration = time.time() - start
-
             if self._on_end:
-                self._on_end(method, path, 500, duration)
+                self._on_end(method, path, 500, time.monotonic() - start)
             if self._on_error:
                 self._on_error(type(exc).__name__, path)
-
-            raise exc
+            raise

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,37 +1,24 @@
 """Tests for get_or_create_counter/gauge/histogram helpers."""
 
 import pytest
-from prometheus_client import REGISTRY, Counter, Gauge, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 
 from fastapi_telemetry import get_or_create_counter, get_or_create_gauge, get_or_create_histogram
+from fastapi_telemetry.helpers import _clear_registry
 
-
-def _unregister(*names: str) -> None:
-    """Remove metrics from the registry so tests are isolated."""
-    for name in names:
-        collector = REGISTRY._names_to_collectors.get(name)
-        if collector:
-            try:
-                REGISTRY.unregister(collector)
-            except Exception:
-                pass
+_TEST_NAMES = (
+    "test_counter_total",
+    "test_gauge",
+    "test_histogram",
+    "test_labeled_counter_total",
+)
 
 
 @pytest.fixture(autouse=True)
 def _cleanup() -> None:
-    _unregister(
-        "test_counter_total",
-        "test_gauge",
-        "test_histogram",
-        "test_labeled_counter_total",
-    )
+    _clear_registry(*_TEST_NAMES)
     yield
-    _unregister(
-        "test_counter_total",
-        "test_gauge",
-        "test_histogram",
-        "test_labeled_counter_total",
-    )
+    _clear_registry(*_TEST_NAMES)
 
 
 def test_creates_counter() -> None:


### PR DESCRIPTION
## Summary

- Fixes #1 — `helpers.py` accessed `REGISTRY._names_to_collectors` (private attribute). Replaced with a module-level `_registry` dict. Added `_clear_registry()` helper for test teardown.
- Fixes #2 — `PrometheusMiddleware` inherited `BaseHTTPMiddleware` which buffers streaming responses. Rewritten as a pure ASGI middleware using `send_wrapper` to capture status code without touching the response body.

## Test plan

- [x] All 17 existing tests pass
- [x] 93% coverage
- [x] Middleware tests verify callbacks still fire correctly with the new ASGI implementation